### PR TITLE
Fix async fileSaveDialog return value under linux

### DIFF
--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -165,7 +165,7 @@ class FileChooserDialog {
   }
 
   void RunAsynchronous() {
-    g_signal_connect(dialog_, "response", G_CALLBACK(OnFileDialogResponseThunk),
+    g_signal_connect(dialog_, "response", G_CALLBACK(OnFileDialogResponse),
                      this);
     if (electron::IsElectron_gtkInitialized()) {
       gtk_native_dialog_show(GTK_NATIVE_DIALOG(dialog_));


### PR DESCRIPTION
#### Description of Change
Instead of returning the [documented](https://www.electronjs.org/docs/latest/api/dialog#dialogshowsavedialogbrowserwindow-options)  return object, under linux `showSaveDialog` returns just a string like its synchronous sibling.

As far as I can tell this is due to a simple oversight in #17054 where the logic [was implemented](https://github.com/electron/electron/blob/f5869b6fb936ba125071f6560ae8c871e4488777/shell/browser/ui/file_dialog_gtk.cc#L245-L255) in the signal handler but the author(@codebytere) forgot to actually utilize the handler.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: Fixed dialog.showSaveDialog returning string instead of object under linux.
